### PR TITLE
Expose a simple API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "cc"
-version = "1.2.32"
+version = "1.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
+checksum = "3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f"
 dependencies = [
  "shlex",
 ]
@@ -439,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.96"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beef09f85ae72cea1ef96ba6870c51e6382ebfa4f0e85b643459331f3daa5be0"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -589,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chrono"
@@ -530,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ httparse = "1.10.1"
 libflate = "1"
 rawzip = "0.3.1"
 serde = { version = "1.0.218", features = ["derive"] }
-serde_json = "1.0.142"
+serde_json = "1.0.143"
 sha2 = "0.10.9"
 surt-rs = "0.1.3"
 url = { version = "2.5.4", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,4 @@ unused_trait_names = { level = "warn", priority = 1 }
 strip = "symbols"
 lto = true
 codegen-units = 1
+panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wacksy"
 version = "0.0.2"
 edition = "2024"
-rust-version = "1.86"
+rust-version = "1.87"
 license = "MIT"
 repository = "https://github.com/bodleian/wacksy"
 description = "Experimental library for writing WACZ achives."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wacksy"
 version = "0.0.2"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.86"
 license = "MIT"
 repository = "https://github.com/bodleian/wacksy"
 description = "Experimental library for writing WACZ achives."

--- a/examples/create_wacz.rs
+++ b/examples/create_wacz.rs
@@ -5,7 +5,7 @@ use wacksy::WACZ;
 fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let warc_file_path: &Path = Path::new("examples/rec-e7e68da067d0-20250423121042981-0.warc.gz");
 
-    let wacz_object = WACZ::from_file(warc_file_path).unwrap();
+    let wacz_object = WACZ::from_file(warc_file_path)?;
     let zipped_wacz = wacz_object.zip().unwrap();
 
     let path: &Path = Path::new("wacz_example.wacz");

--- a/examples/create_wacz.rs
+++ b/examples/create_wacz.rs
@@ -1,37 +1,13 @@
-use std::error::Error;
-use std::{fs, path::Path};
-use wacksy::{Wacz, datapackage::DataPackage, indexer::Index};
+use std::path::Path;
+use std::{error::Error, fs};
+use wacksy::WACZ;
 
 fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let warc_file_path: &Path = Path::new("examples/rec-e7e68da067d0-20250423121042981-0.warc.gz");
 
-    let warc_file = fs::read(warc_file_path)?;
+    let compressed_wacz = WACZ::from_file(warc_file_path).zip().unwrap();
 
-    let index = Index::index_file(warc_file_path)?;
-    println!("Read {} records", index.2);
-
-    let cdxj_index_bytes = index.0.to_string().into_bytes();
-    let pages_index_bytes = index.1.to_string().into_bytes();
-
-    let data_package = DataPackage::new(&warc_file, &index)?;
-    let data_package_digest = DataPackage::digest(&data_package)?;
-
-    let data_package_digest_bytes = serde_json::to_vec(&data_package_digest)?;
-    let data_package_bytes = serde_json::to_vec(&data_package)?;
-
-    let wacz_object: Wacz = {
-        Wacz {
-            warc_file,
-            data_package_bytes,
-            data_package_digest_bytes,
-            cdxj_index_bytes,
-            pages_index_bytes,
-        }
-    };
-
-    // This needs to be parsed into a file!
-    let wacz_data: Vec<u8> = Wacz::zip_dir(&wacz_object)?;
     let path: &Path = Path::new("wacz_example.wacz");
-    fs::write(path, wacz_data)?;
+    fs::write(path, compressed_wacz)?;
     Ok(())
 }

--- a/examples/create_wacz.rs
+++ b/examples/create_wacz.rs
@@ -5,9 +5,10 @@ use wacksy::WACZ;
 fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let warc_file_path: &Path = Path::new("examples/rec-e7e68da067d0-20250423121042981-0.warc.gz");
 
-    let compressed_wacz = WACZ::from_file(warc_file_path).zip().unwrap();
+    let wacz_object = WACZ::from_file(warc_file_path).unwrap();
+    let zipped_wacz = wacz_object.zip().unwrap();
 
     let path: &Path = Path::new("wacz_example.wacz");
-    fs::write(path, compressed_wacz)?;
+    fs::write(path, zipped_wacz)?;
     Ok(())
 }

--- a/examples/create_wacz.rs
+++ b/examples/create_wacz.rs
@@ -4,7 +4,6 @@ use wacksy::WACZ;
 
 fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let warc_file_path: &Path = Path::new("examples/rec-e7e68da067d0-20250423121042981-0.warc.gz");
-
     let wacz_object = WACZ::from_file(warc_file_path)?;
     let zipped_wacz = wacz_object.zip().unwrap();
 

--- a/src/datapackage.rs
+++ b/src/datapackage.rs
@@ -1,6 +1,10 @@
-//! Types for defining a datapackage.json file.
+//! Structured definition of a datapackage.json file.
+//! According to [the spec](https://specs.webrecorder.net/wacz/1.1.1/#datapackage-json):
 //!
-//! The file should look something like this when complete:
+//! > The file **must** be present at the root of the WACZ which serves as the manifest for the web archive
+//! > and is compliant with the [FRICTIONLESS-DATA-PACKAGE](https://specs.frictionlessdata.io/data-package/) specification.
+//!
+//! The file should look something like this when serialised to json:
 //!
 //! ```json
 //! {
@@ -24,8 +28,6 @@
 //!   ]
 //! }
 //! ```
-//!
-//! [Link to spec](https://specs.webrecorder.net/wacz/1.1.1/#datapackage-json)
 
 use chrono::Local;
 use serde::{Deserialize, Serialize};
@@ -35,18 +37,22 @@ use std::{error::Error, ffi::OsStr, fmt, fs, path::Path};
 
 use crate::{WACZ_VERSION, indexer::Index};
 
-/// A [frictionless datapackage](https://specs.frictionlessdata.io/data-package/).
+/// The main datapackage struct.
 #[derive(Serialize, Deserialize)]
 pub struct DataPackage {
+    /// In WACZ 1.1.1 this value is `data-package`.
     pub profile: String,
+    /// See [`WACZ_VERSION`] constant.
     pub wacz_version: String,
+    /// WACZ creation date, this is set to local datetime in [RFC 3399 format](https://rfc3339.date/).
     pub created: String,
+    /// The name of the software used to create the WACZ file, in this case `wacksy 0.0.2`.
     pub software: String,
+    /// List of file names, paths, sizes and fixity for all files contained in the WACZ.
     pub resources: Vec<DataPackageResource>,
 }
 
-/// A datapackage resource is anything which needs
-/// to be defined in the datapackage.
+/// A resource listed in the datapackage.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DataPackageResource {
     #[serde(rename = "name")]
@@ -54,6 +60,8 @@ pub struct DataPackageResource {
     pub path: String,
     pub hash: String,
     pub bytes: usize,
+    /// The raw content of the resource in bytes,
+    /// not passed through to serde when serialising to json.
     #[serde(skip)]
     pub content: Vec<u8>,
 }

--- a/src/datapackage.rs
+++ b/src/datapackage.rs
@@ -49,6 +49,7 @@ pub struct DataPackage {
 /// to be defined in the datapackage.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DataPackageResource {
+    #[serde(rename = "name")]
     pub file_name: String,
     pub path: String,
     pub hash: String,

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -32,14 +32,15 @@ impl Index {
     /// # Indexer
     ///
     /// This function sets off looping through the
-    /// records to build the index and create the
-    /// pages.jsonl file.
+    /// records to build the CDXJ and Pages.jsonl file.
     ///
     /// # Errors
     ///
-    /// Will return a `std::io::Error` from
-    /// `WarcReader::from_path`/`from_path_gzip`
-    /// in case of any problem reading the Warc file.
+    /// Returns a [file io error](IndexingError::WarcFileError) from
+    /// `WarcReader::from_path`/`from_path_gzip` in case of any problem reading
+    /// the WARC file. An [unrecoverable error](IndexingError::CriticalRecordError)
+    /// when reading the WARC record will stop the indexer and propogate
+    /// all the way up to the top.
     pub fn index_file(warc_file_path: &Path) -> Result<Self, IndexingError> {
         // this looping function accepts a generic type which
         // this allows us to pass in both gzipped and non-gzipped records
@@ -137,7 +138,7 @@ impl fmt::Display for NumberOfRecordsRead {
     }
 }
 
-/// This index struct contains a list of individual [CDX(J) Records](CDXJIndexRecord).
+/// Contains a list of [CDX(J) records](CDXJIndexRecord).
 pub struct CDXJIndex(Vec<CDXJIndexRecord>);
 impl fmt::Display for CDXJIndex {
     fn fmt(&self, message: &mut fmt::Formatter) -> fmt::Result {
@@ -154,8 +155,7 @@ impl fmt::Display for PageIndex {
     }
 }
 
-/// A record which would make up
-/// a line in a CDX(J) index.
+/// A record which would make up a line in a [CDX(J) index](CDXJIndex).
 pub struct CDXJIndexRecord {
     /// The date and time when the web archive snapshot was created
     pub timestamp: RecordTimestamp,

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,7 +1,6 @@
 //! Reads the WARC file and composes a CDX(J) index.
 
 use libflate::gzip::MultiDecoder;
-use serde::{Deserialize, Serialize};
 use std::ffi::OsStr;
 use std::fmt;
 use std::fs::File;
@@ -26,7 +25,12 @@ pub use record_url::RecordUrl;
 mod record_status;
 pub use record_status::RecordStatus;
 
-pub struct Index(pub CDXJIndex, pub PageIndex, pub NumberOfRecordsRead);
+#[derive(Debug)]
+pub struct Index {
+    pub cdxj: CDXJIndex,
+    pub pages: PageIndex,
+    pub records_read: NumberOfRecordsRead,
+}
 
 impl Index {
     /// # Indexer
@@ -101,11 +105,11 @@ impl Index {
                 }
             }
 
-            return Index(
-                CDXJIndex(cdxj_index),
-                PageIndex(page_index),
-                NumberOfRecordsRead(record_count),
-            );
+            return Index {
+                cdxj: CDXJIndex(cdxj_index),
+                pages: PageIndex(page_index),
+                records_read: NumberOfRecordsRead(record_count),
+            };
         }
 
         if warc_file_path.extension() == Some(OsStr::new("gz")) {
@@ -121,6 +125,7 @@ impl Index {
         };
     }
 }
+#[derive(Debug)]
 pub struct NumberOfRecordsRead(usize);
 impl fmt::Display for NumberOfRecordsRead {
     fn fmt(&self, message: &mut fmt::Formatter) -> fmt::Result {
@@ -129,6 +134,7 @@ impl fmt::Display for NumberOfRecordsRead {
 }
 
 /// This index struct contains a list of individual [CDX(J) Records](CDXJIndexRecord).
+#[derive(Debug)]
 pub struct CDXJIndex(Vec<CDXJIndexRecord>);
 impl fmt::Display for CDXJIndex {
     fn fmt(&self, message: &mut fmt::Formatter) -> fmt::Result {
@@ -137,6 +143,7 @@ impl fmt::Display for CDXJIndex {
     }
 }
 
+#[derive(Debug)]
 pub struct PageIndex(Vec<PageRecord>);
 impl fmt::Display for PageIndex {
     fn fmt(&self, message: &mut fmt::Formatter) -> fmt::Result {
@@ -243,28 +250,5 @@ impl fmt::Display for CDXJIndexRecord {
             self.status,
             self.filename
         );
-    }
-}
-
-// This has not been properly implemented yet!
-#[doc(hidden)]
-#[derive(Debug, Serialize, Deserialize)]
-pub struct PageTitle(String);
-
-impl PageTitle {
-    // pub fn new(record: &Record<BufferedBody>) -> Result<Self, IndexingError> {
-    //     if let Some(record_digest) = record.header(WarcHeader::PayloadDigest) {
-    //         return Ok(Self(record_digest.to_string()));
-    //     } else {
-    //         return Err(IndexingError::ValueNotFound(format!(
-    //             "Record {} does not have a payload digest in the WARC header",
-    //             record.warc_id()
-    //         )));
-    //     }
-    // }
-}
-impl fmt::Display for PageTitle {
-    fn fmt(&self, message: &mut fmt::Formatter) -> fmt::Result {
-        return write!(message, "{}", self.0);
     }
 }

--- a/src/indexer/page_record.rs
+++ b/src/indexer/page_record.rs
@@ -1,6 +1,5 @@
 use crate::indexer::{
-    PageTitle, RecordContentType, RecordStatus, RecordTimestamp, RecordUrl,
-    indexing_errors::IndexingError,
+    RecordContentType, RecordStatus, RecordTimestamp, RecordUrl, indexing_errors::IndexingError,
 };
 use serde::Serialize;
 use std::fmt;
@@ -13,9 +12,6 @@ pub struct PageRecord {
     pub timestamp: RecordTimestamp,
     /// The URL that was archived
     pub url: RecordUrl,
-    /// A string describing the resource
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<PageTitle>,
 }
 impl PageRecord {
     /// # Create page record
@@ -53,11 +49,7 @@ impl PageRecord {
                 .contains(&mime.to_string().as_str())
             && status == RecordStatus(200)
         {
-            let parsed_record = Self {
-                timestamp,
-                url,
-                title: None,
-            };
+            let parsed_record = Self { timestamp, url };
             return Ok(parsed_record);
         } else {
             // if the record is not one of the types we want,

--- a/src/indexer/record_content_type.rs
+++ b/src/indexer/record_content_type.rs
@@ -2,7 +2,6 @@ use crate::indexer::indexing_errors::IndexingError;
 use std::{fmt, str};
 use warc::{BufferedBody, Record, RecordType};
 
-#[derive(Debug)]
 pub struct RecordContentType(String);
 
 impl RecordContentType {

--- a/src/indexer/record_digest.rs
+++ b/src/indexer/record_digest.rs
@@ -2,7 +2,6 @@ use crate::indexer::indexing_errors::IndexingError;
 use std::fmt;
 use warc::{BufferedBody, Record, WarcHeader};
 
-#[derive(Debug)]
 pub struct RecordDigest(String);
 
 impl RecordDigest {

--- a/src/indexer/record_status.rs
+++ b/src/indexer/record_status.rs
@@ -2,7 +2,7 @@ use crate::indexer::indexing_errors::IndexingError;
 use std::fmt;
 use warc::{BufferedBody, Record};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(PartialEq, Eq)]
 pub struct RecordStatus(pub u16);
 
 impl RecordStatus {
@@ -53,7 +53,6 @@ mod tests {
         let status = "200";
         let body = format!("HTTP/1.1 {status}\n");
         let record = Record::<BufferedBody>::new().add_body(body);
-
         let generated_status = RecordStatus::new(&record).unwrap().to_string();
 
         assert_eq!(generated_status, status);

--- a/src/indexer/record_timestamp.rs
+++ b/src/indexer/record_timestamp.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use warc::{BufferedBody, Record, WarcHeader};
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct RecordTimestamp(DateTime<chrono::FixedOffset>);
 
 impl RecordTimestamp {
@@ -52,7 +52,6 @@ mod tests {
         let mut headers = Record::<BufferedBody>::new();
         headers.set_header(WarcHeader::Date, timestamp).unwrap();
         let record = headers.add_body("");
-
         let generated_timestamp = RecordTimestamp::new(&record).unwrap().to_string();
 
         assert_eq!(generated_timestamp, "20250806133728");

--- a/src/indexer/record_url.rs
+++ b/src/indexer/record_url.rs
@@ -5,7 +5,7 @@ use surt_rs::generate_surt;
 use url::Url;
 use warc::{BufferedBody, Record, WarcHeader};
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
 pub struct RecordUrl(Url);
 
 impl RecordUrl {

--- a/src/indexer/warc_filename.rs
+++ b/src/indexer/warc_filename.rs
@@ -3,7 +3,6 @@ use std::fmt;
 use std::path::Path;
 use warc::{BufferedBody, Record, WarcHeader};
 
-#[derive(Debug)]
 pub struct WarcFilename(String);
 
 impl WarcFilename {
@@ -55,11 +54,9 @@ mod tests {
     fn valid_filename() {
         let filename = "example.warc";
         let path = Path::new(filename);
-
         let mut headers = Record::<BufferedBody>::new();
         headers.set_header(WarcHeader::Filename, filename).unwrap();
         let record = headers.add_body("");
-
         let parsed_filename = WarcFilename::new(&record, path).unwrap().to_string();
 
         assert_eq!(parsed_filename, filename);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,11 +13,10 @@ use crate::{
 };
 
 /// Set the WACZ version of the file being created,
-/// deprecated in WACZ 1.2.0.
+/// deprecated in [WACZ 1.2.0](https://specs.webrecorder.net/wacz/1.2.0/#changes).
 pub const WACZ_VERSION: &str = "1.1.1";
 
-/// This struct contains various resources as
-/// byte arrays, ready to be zipped.
+/// A WACZ object
 pub struct WACZ {
     pub datapackage: DataPackage,
     pub datapackage_digest: DataPackageDigest,
@@ -25,6 +24,18 @@ pub struct WACZ {
     pub pages_index: PageIndex,
 }
 impl WACZ {
+    /// # Create WACZ from WARC file
+    ///
+    /// This is the main function of the library, it takes a path to a WARC file,
+    /// reads through it to produce CDXJ and page.json indexes. Everything is
+    /// wrapped into a [datapackage], and then wrapped _again_ into a [WACZ] struct.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`WaczError`], which can be caused by a problem in either the
+    /// [indexer](IndexingError) or the [datapackage](DataPackageError). As the
+    /// datapackage depends on the index being complete, any problem with the
+    /// indexer will return early without continuing.
     pub fn from_file(warc_file_path: &Path) -> Result<Self, WaczError> {
         match Index::index_file(warc_file_path) {
             Ok(index) => {
@@ -51,12 +62,12 @@ impl WACZ {
     }
     /// # Zipper
     ///
-    /// This function should accept a WACZ struct.
-    /// explain what else
+    /// Takes a WACZ struct and zips up every element into a zip file.
+    /// This function is mostly a wrapper around [rawzip](https://crates.io/crates/rawzip).
     ///
     /// # Errors
     ///
-    /// Will return a rawzip error if anything goes wrong with adding files
+    /// Returns a `rawzip` error if anything goes wrong with adding files
     /// files to the archive.
     pub fn zip(&self) -> Result<Vec<u8>, rawzip::Error> {
         fn add_file_to_archive(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use rawzip::{CompressionMethod, ZipArchiveWriter, ZipDataWriter};
 
 use crate::{
-    datapackage::{DataPackage, DataPackageDigest},
+    datapackage::{DataPackage, DataPackageDigest, DataPackageError},
     indexer::{CDXJIndex, Index, PageIndex},
 };
 
@@ -25,20 +25,18 @@ pub struct WACZ {
     pub pages_index: PageIndex,
 }
 impl WACZ {
-    #[must_use]
-    pub fn from_file(warc_file_path: &Path) -> Self {
+    pub fn from_file(warc_file_path: &Path) -> Result<Self, DataPackageError> {
         let index = Index::index_file(warc_file_path).unwrap();
-        let datapackage = DataPackage::new(warc_file_path, &index).unwrap();
-        let datapackage_digest = datapackage.digest().unwrap();
+        let datapackage = DataPackage::new(warc_file_path, &index)?;
+        let datapackage_digest = datapackage.digest()?;
 
-        return Self {
+        return Ok(Self {
             datapackage,
             datapackage_digest,
             cdxj_index: index.cdxj,
             pages_index: index.pages,
-        };
+        });
     }
-
     /// # Zipper
     ///
     /// This function should accept a WACZ struct.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,10 +1,10 @@
-use std::{fs, path::Path};
+use std::{error::Error, fs, path::Path};
 use wacksy::indexer;
 
 const WARC_PATH: &str = "tests/rec-e7e68da067d0-20250423121042981-0.warc.gz";
 
 #[test]
-fn create_cdxj_index() -> Result<(), std::io::Error> {
+fn create_cdxj_index() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let warc_file_path: &Path = Path::new(WARC_PATH);
     let index = indexer::Index::index_file(warc_file_path)?;
     let generated_cdxj_index = index.cdxj.to_string();
@@ -15,7 +15,7 @@ fn create_cdxj_index() -> Result<(), std::io::Error> {
 }
 
 #[test]
-fn create_pages_index() -> Result<(), std::io::Error> {
+fn create_pages_index() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let warc_file_path: &Path = Path::new(WARC_PATH);
     let index = indexer::Index::index_file(warc_file_path)?;
     let generated_pages_index = index.pages.to_string();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7,7 +7,7 @@ const WARC_PATH: &str = "tests/rec-e7e68da067d0-20250423121042981-0.warc.gz";
 fn create_cdxj_index() -> Result<(), std::io::Error> {
     let warc_file_path: &Path = Path::new(WARC_PATH);
     let index = indexer::Index::index_file(warc_file_path)?;
-    let generated_cdxj_index = index.0.to_string();
+    let generated_cdxj_index = index.cdxj.to_string();
     let example_cdxj_index =
         fs::read_to_string(Path::new("tests/wacz_example/indexes/index.cdxj"))?;
     assert_eq!(generated_cdxj_index, example_cdxj_index);
@@ -18,7 +18,7 @@ fn create_cdxj_index() -> Result<(), std::io::Error> {
 fn create_pages_index() -> Result<(), std::io::Error> {
     let warc_file_path: &Path = Path::new(WARC_PATH);
     let index = indexer::Index::index_file(warc_file_path)?;
-    let generated_pages_index = index.1.to_string();
+    let generated_pages_index = index.pages.to_string();
     let example_pages_index =
         fs::read_to_string(Path::new("tests/wacz_example/pages/pages.jsonl"))?;
     assert_eq!(generated_pages_index, example_pages_index);


### PR DESCRIPTION
So far this library has had a kind of ad-hoc interface based on just me testing things out in development.

This PR aims to expose some user-friendly functions, with the goal of eventually wrapping all this up in a nice command line interface, as requested in issue #43.

`from_file` takes a WARC file path, runs the indexer, and returns a WACZ struct
`zip` takes the WACZ struct, and zips it up with RawZip

Todo:
- [x] Sort out return types / error handling.
- [x] Document these two functions

There's a lot going on in this PR, the main difference in approach is that we're passing all the _content_ through the datapackage, then the datapackage and everything else goes through to the zipper at the end. I want to leave room for future functionality, like skipping the indexing step, or, one of my main motivations for writing this library, wrapping other metadata into the final file.